### PR TITLE
Fixing rendering bug in streamlit 1.33

### DIFF
--- a/st_copy_to_clipboard/frontend/main.js
+++ b/st_copy_to_clipboard/frontend/main.js
@@ -13,6 +13,8 @@ function sendValue(value) {
  * component gets new data from Python.
  */
 function onRender(event) {
+  // Setting FrameHeight
+  Streamlit.setFrameHeight(100)
   // Only run the render code the first time the component is loaded.
   if (!window.rendered) {
     const { text, before_copy_label, after_copy_label, show_text } = event.detail.args;


### PR DESCRIPTION
Set Frame Height Parameter as Custom components with undefined frame heights will render with a height of 0 (and would therefore be invisible) in streamlit 1.33 https://discuss.streamlit.io/t/version-1-33-0/66360 [other changes section]